### PR TITLE
remove SizedBatch

### DIFF
--- a/src/Minibatch.jl
+++ b/src/Minibatch.jl
@@ -1,6 +1,6 @@
 module Minibatch
 
-export VectorBatch, SizedBatch, MaskedBatch, softmax
+export VectorBatch, MaskedBatch, softmax
 
 ################
 # NN functions #
@@ -26,6 +26,7 @@ const AxisInfo{N} = NTuple{N, Bool}
 # currently it's intentionally not <:AbstractArray
 # because that provides a lot of magic I want to avoid
 abstract type AbstractBatch{T, A} end
+axisinfo(::AbstractBatch{T, A}) where {T, A} = A
 
 struct VectorBatch{T, A} <: AbstractBatch{T, A}
     data::Vector{T}
@@ -36,64 +37,37 @@ Base.length(b::VectorBatch) = length(b.data)
 Base.:(==)(a::VectorBatch{T1, A}, b::VectorBatch{T2, A}) where {T1, T2, A} = a.data == b.data
 Base.isapprox(a::VectorBatch{T1, A}, b::VectorBatch{T2, A}) where {T1, T2, A} = a.data ≈ b.data
 
-struct SizedBatch{T, A} <: AbstractBatch{T, A}
+mutable struct MaskedBatch{T, A} <: AbstractBatch{T, A}
     data
-    sizes::Matrix{Int}
+    mask
 end
-function SizedBatch(data::Vector{T}, axes::AxisInfo{N}) where {T, N}
-    dims = tuple((b ? maximum(size(v, d) for v in data)
-                    : size(first(data), d) for (d, b) in enumerate(axes))...,
-                 length(data))
-    batch = fill!(similar(first(data), dims), 0)
-    sizes = zeros(Int, N, length(data))
-    for (i, example) in enumerate(data)
-        setindex!(batch, example, indices(example)..., i)
-        sizes[:, i] = collect(size(example))
+function MaskedBatch(data::Vector, axes::AxisInfo)
+    dims = (a ? maximum(size(v, d) for v in data) : size(first(data), d) for (d, a) in enumerate(axes))
+    maskdims = (a ? maximum(size(v, d) for v in data) : 1 for (d, a) in enumerate(axes))
+    batch = fill!(similar(first(data), dims..., length(data)), 0)
+    mask = fill!(similar(first(data), maskdims..., length(data)), 0)
+    for (i, x) in enumerate(data)
+        setindex!(batch, x, indices(x)..., i)
+        mask[(1:(a ? size(x, d) : 1) for (d, a) in enumerate(axes))..., i] .= 1
     end
-    return SizedBatch{T, axes}(batch, sizes)
+    return MaskedBatch{typeof(first(data)), axes}(batch, mask)
 end
-
-# TODO make batch size a part of the type when we have static dims
-Base.length(b::SizedBatch) = last(size(b.sizes))
-Base.:(==)(a::SizedBatch{T1, A}, b::SizedBatch{T2, A}) where {T1, T2, A} = a.data == b.data && a.sizes == b.sizes
-Base.isapprox(a::SizedBatch{T1, A}, b::SizedBatch{T2, A}) where {T1, T2, A} = a.data ≈ b.data && a.sizes == b.sizes
-
-SizedBatch(b::VectorBatch{T, A}) where {T, A} = SizedBatch(b.data, A)
-function VectorBatch(b::SizedBatch{T, A}) where {T, A}
-    bs = last(size(b.sizes))
-    xs = [b.data[(1:n for n in b.sizes[:, i])..., i] for i in 1:bs]
+function sizes(b::MaskedBatch{T, A}) where {T, A}
+    bs = length(b)
+    mask = Array{Int}(b.mask)
+    return vcat((a ? sum(mask, d)[(1 for _ in A)..., :]' :
+                 fill(size(b.data, d), bs)' for (d, a) in enumerate(A))...)
+end
+function VectorBatch(b::MaskedBatch{T, A}) where {T, A}
+    s = sizes(b)
+    xs = [b.data[(1:n for n in s[:, i])..., i] for i in 1:length(b)]
     return VectorBatch{T, A}(xs)
 end
 
-mutable struct MaskedBatch{T, A} <: AbstractBatch{T, A}
-    data
-    sizes::Matrix{Int}
-    mask
-    MaskedBatch{T, A}(data, sizes) where {T, A} = new(data, sizes)
-    MaskedBatch{T, A}(data, sizes, mask) where {T, A} = new(data, sizes, mask)
-end
-function MaskedBatch(b::SizedBatch{T, A}) where {T, A}
-    dims = tuple((a ? size(b.data, d) : 1 for (d, a) in enumerate(A))...,
-                 last(size(b.sizes)))
-    mask = fill!(similar(b.data, dims), 0)
-    for i in 1:last(size(b.sizes))
-        mask[(1:(A[d] ? n : 1) for (d, n) in enumerate(b.sizes[:, i]))..., i] .= 1
-    end
-    return MaskedBatch{T, A}(b.data, b.sizes, mask)
-end
-SizedBatch(b::MaskedBatch{T, A}) where {T, A} = SizedBatch{T, A}(b.data, b.sizes)
-MaskedBatch(data::Vector, axes::AxisInfo) = MaskedBatch(SizedBatch(data, axes))
-MaskedBatch(b::VectorBatch) = MaskedBatch(SizedBatch(b))
-VectorBatch(b::MaskedBatch) = VectorBatch(SizedBatch(b))
-
-Base.length(b::MaskedBatch) = last(size(b.sizes))
-Base.:(==)(a::MaskedBatch{T1, A}, b::MaskedBatch{T2, A}) where {T1, T2, A} = a.data == b.data && a.sizes == b.sizes
-Base.isapprox(a::MaskedBatch{T1, A}, b::MaskedBatch{T2, A}) where {T1, T2, A} = a.data ≈ b.data && a.sizes == b.sizes
-
-const SMBatch{T, B} = Union{SizedBatch{T, B}, MaskedBatch{T, B}}
-batchtype(::VectorBatch) = VectorBatch
-batchtype(::SizedBatch) = SizedBatch
-batchtype(::MaskedBatch) = MaskedBatch
+MaskedBatch(b::VectorBatch{T, A}) where {T, A} = MaskedBatch(b.data, A)
+Base.length(b::MaskedBatch) = last(size(b.mask))
+Base.:(==)(a::MaskedBatch{T1, A}, b::MaskedBatch{T2, A}) where {T1, T2, A} = a.data == b.data && a.mask == b.mask
+Base.isapprox(a::MaskedBatch{T1, A}, b::MaskedBatch{T2, A}) where {T1, T2, A} = a.data ≈ b.data && a.mask == b.mask
 
 # TODO also CatBatch using CatArrays.jl?
 
@@ -101,108 +75,100 @@ batchtype(::MaskedBatch) = MaskedBatch
 # Methods/overdubs for batch types #
 ####################################
 
-function _checkbatchsizes(xs::Vararg{AbstractBatch})
+function _samebatchsizes(xs::Vararg{AbstractBatch})
     bs = length(first(xs))
     all(length(x) == bs for x in xs) || error("batch size mismatch")
     return bs
 end
 function _vbcall(f, T, xs...)
-    batchsize = _checkbatchsizes((x for x in xs if x isa T)...)
-    return T([f((x isa T ? x.data[i] : x for x in xs)...) for i in 1:batchsize])
+    bs = _samebatchsizes((x for x in xs if x isa T)...)
+    return T([f((x isa T ? x.data[i] : x for x in xs)...) for i in 1:bs])
 end
-Base.:+(xs::Vararg{Union{T, AbstractArray}}) where T<:VectorBatch = _vbcall(+, T, xs...)
-Base.:-(xs::Vararg{Union{T, AbstractArray}}) where T<:VectorBatch = _vbcall(-, T, xs...)
-Base.:*(xs::Vararg{Union{T, AbstractArray}}) where T<:VectorBatch = _vbcall(*, T, xs...)
-Base.:/(xs::Vararg{Union{T, AbstractArray}}) where T<:VectorBatch = _vbcall(/, T, xs...)
+Base.:+(xs::Vararg{Union{T, AbstractArray, Number}}) where T<:VectorBatch = _vbcall(+, T, xs...)
+Base.:-(xs::Vararg{Union{T, AbstractArray, Number}}) where T<:VectorBatch = _vbcall(-, T, xs...)
+Base.:*(xs::Vararg{Union{T, AbstractArray, Number}}) where T<:VectorBatch = _vbcall(*, T, xs...)
+Base.:/(xs::Vararg{Union{T, AbstractArray, Number}}) where T<:VectorBatch = _vbcall(/, T, xs...)
 Base.getindex(x::T, inds...) where T<:VectorBatch = _vbcall(getindex, T, x, inds...)
-Base.broadcast(f, xs::Vararg{Union{T, AbstractArray}}) where T<:VectorBatch = _vbcall(broadcast, T, f, xs...)
+Base.broadcast(f, xs::Vararg{Union{T, AbstractArray, Number}}) where T<:VectorBatch = _vbcall(broadcast, T, f, xs...)
+
+# _vbcall is unsafe for contractions because it doesn't check that axes
+# which must have static dimension actually do at the type level. We
+# could fix that by including explicit checks, as in the methods below,
+# but even when _vbcall wouldn't break.
+function Base.:*(a::VectorBatch{T, A}, b::AbstractVector) where {T<:AbstractMatrix, A}
+    A[2] == false || error("cannot contract axes with static and dynamic dimension")
+    return VectorBatch{T, (A[1],)}([a.data[i] * b for i in 1:length(a)])
+end
+
+function Base.:*(a::VectorBatch{T, A}, b::VectorBatch{T, B}) where {T<:AbstractMatrix, A, B}
+    A[2] == B[1] || error("cannot contract axes with static and dynamic dimension")
+    bs = _samebatchsizes(a, b)
+    return VectorBatch{T, (A[1], B[2])}([a.data[i] * b.data[i] for i in 1:bs])
+end
+
+function Base.:*(a::VectorBatch{T1, A}, b::VectorBatch{T2, B}) where {T1<:AbstractMatrix, T2<:AbstractVector, A, B}
+    A[2] == B[1] || error("cannot contract axes with static and dynamic dimension")
+    bs = _samebatchsizes(a, b)
+    return VectorBatch{T, (A[1],)}([a.data[i] * b.data[i] for i in 1:bs])
+end
 
 _rezero!(b::MaskedBatch) = b.data .*= b.mask
-function _rezero!(b::SizedBatch)
-    b = MaskedBatch(b)
-    _rezero!(b)
-    return SizedBatch(b)
-end
 # TODO this should really be promote_containersize
-function _checksizes(xs::Vararg{T}) where T<:SMBatch{T2, B} where {T2, B}
-    fs = first(xs).sizes
+function _samemasks(xs::Vararg{<:MaskedBatch{T2, B}}) where {T2, B}
+    fs = first(xs).mask
     if any(B)
-        all(x.sizes == fs for x in xs) || error("SizedBatch or MaskedBatch size mismatch")
+        all(x.mask == fs for x in xs) || error("MaskedBatch size mismatch")
     end
     return fs
 end
-function _zeropreserving(f)
-    # ideally would do this at compile time
-    return method_exists(f, (Float64,)) ? f(0.0) == 0.0 : false
-end
-function Base.broadcast(f, xs::Vararg{Union{T, AbstractArray}}) where T<:SMBatch
-    sizes = _checksizes((x for x in xs if x isa T)...)
-    res = T(broadcast(f, (x isa T ? x.data : x for x in xs)...), sizes)
-    T<:MaskedBatch && (res.mask = first(xs).mask)
-    (T<:MaskedBatch || !_zeropreserving(f)) && _rezero!(res)
+function Base.broadcast(f, xs::Vararg{Union{T, AbstractArray}}) where T<:MaskedBatch
+    mask = _samemasks((x for x in xs if x isa T)...)
+    res = T(broadcast(f, (x isa T ? x.data : x for x in xs)...), mask)
+    _rezero!(res)
     return res
 end
-Base.:+(xs::Vararg{Union{T, AbstractArray}}) where T<:SMBatch = broadcast(+, xs...)
-Base.:-(xs::Vararg{Union{T, AbstractArray}}) where T<:SMBatch = broadcast(-, xs...)
+Base.:+(xs::Vararg{Union{T, AbstractArray}}) where T<:MaskedBatch = broadcast(+, xs...)
+Base.:-(xs::Vararg{Union{T, AbstractArray}}) where T<:MaskedBatch = broadcast(-, xs...)
 
 # contractions between axes with static dimension
 
-function Base.dot(a::AbstractVector, b::SMBatch{T, (false,)}) where {T}
-    res = batchtype(b){T, ()}(b.data'*a, Matrix{Int}(0, length(b)))
-    b isa MaskedBatch && (res.mask = b.mask[1])
-    return res
+function Base.dot(a::AbstractVector, b::MaskedBatch{T, (false,)}) where {T}
+    return MaskedBatch{T, ()}(b.data'*a, b.mask[1])
 end
-function Base.dot(a::SizedBatch{T, (false,)}, b::AbstractVector) where {T}
-    res = batchtype(a){T, ()}(a.data'*b, Matrix{Int}(0, length(a)))
-    a isa MaskedBatch && (res.mask = a.mask[1])
-    return res
+function Base.dot(a::MaskedBatch{T, (false,)}, b::AbstractVector) where {T}
+    return MaskedBatch{T, ()}(a.data'*b, a.mask[1])
 end
 
-function Base.:*(a::AbstractMatrix, b::SMBatch{T, (false,)}) where {T}
-    sizes = fill(similar(b.sizes), size(a, 1))
-    res = batchtype(b){T, (false,)}(a * b.data, sizes)
-    b isa MaskedBatch && (res.mask = b.mask)
-    return res
+function Base.:*(a::AbstractMatrix, b::MaskedBatch{T, (false,)}) where {T}
+    return MaskedBatch{T, (false,)}(a * b.data, b.mask)
 end
-function Base.:*(a::SMBatch{T, A}, b::AbstractVector) where {T<:AbstractMatrix, A}
+function Base.:*(a::MaskedBatch{T, A}, b::AbstractVector) where {T<:AbstractMatrix, A}
     A[2] == false || error("cannot contract axes with static and dynamic dimension")
     s1, s2, bs = size(a.data)
     data = reshape(reshape(a.data, s1, s2*bs) * b, s1, bs)
-    res = batchtype(a){T, (A[1],)}(data, a.sizes[1:1, :])
-    a isa MaskedBatch && (res.mask = a.mask[:, 1, :])
+    return MaskedBatch{T, (A[1],)}(data, a.mask[:, 1, :])
 end
 
-function Base.:*(a::AbstractMatrix, b::SMBatch{T, B}) where {T<:AbstractMatrix, B}
+function Base.:*(a::AbstractMatrix, b::MaskedBatch{T, B}) where {T<:AbstractMatrix, B}
     B[1] == false || error("cannot contract axes with static and dynamic dimension")
     s1, s2, bs = size(b.data)
     data = reshape(a * reshape(b.data, s1, s2*bs), size(a, 1), s2, bs)
-    sizes = copy(b.sizes)
-    sizes[1, :] .= size(a, 1)
-    res = batchtype(b){T, B}(data, sizes)
-    b isa MaskedBatch && (res.mask = b.mask)
-    return res
+    return MaskedBatch{T, B}(data, b.mask)
 end
-function Base.:*(a::SMBatch{T, A}, b::AbstractMatrix) where {T<:AbstractMatrix, A}
+function Base.:*(a::MaskedBatch{T, A}, b::AbstractMatrix) where {T<:AbstractMatrix, A}
     A[2] == false || error("cannot contract axes with static and dynamic dimension")
     s1, s2, bs = size(a.data)
     amat = reshape(permutedims(a.data, [2, 3]), s1*bs, s2)
     data = permutedims(reshape(amat * b, s1, bs, size(b, 2)), [2, 3])
-    sizes = copy(b.sizes)
-    sizes[2, :] .= size(b, 2)
-    res = batchtype(a){T, A}(data, sizes)
-    a isa MaskedBatch && (res.mask = a.mask)
-    return res
+    return MaskedBatch{T, A}(data, a.mask)
 end
 
 # contractions between axes with dynamic dimension
 
 # TODO should things work when dynamic dimension = 0?
-function Base.dot(a::SMBatch{T, A}, b::SMBatch{T, B}) where {T<:AbstractVector, A, B}
-    batchsize = last(size(_checksizes(a, b)))
+function Base.dot(a::MaskedBatch{T, A}, b::MaskedBatch{T, B}) where {T<:AbstractVector, A, B}
     data = sum(a.data .* b.data, 1)[1, :] # TODO replace with batchedmul when fast
-    res = batchtype(a){T, ()}(data, Matrix{Int}(0, batchsize))
-    a isa MaskedBatch && (res.mask = a.mask[1])
-    return res
+    return MaskedBatch{T, ()}(data, a.mask[1])
 end
 
 # the methods below use batched matrix-matrix and matrix-vector products;
@@ -210,6 +176,7 @@ end
 # wrapped in Base; here we implement sequential fallbacks but TODO these
 # functions should actually be in another package and have those fast methods
 function batchedmul(a::AbstractArray{T, 3}, b::AbstractArray{T, 2}) where {T}
+    (bs = size(a, 3)) == size(b, 2) || error("batch size mismatch")
     res = similar(a, size(a, 1), bs)
     for i in 1:bs
         res[:, i] = a[:, :, i] * b[:, i]
@@ -217,6 +184,7 @@ function batchedmul(a::AbstractArray{T, 3}, b::AbstractArray{T, 2}) where {T}
     return res
 end
 function batchedmul(a::AbstractArray{T, 3}, b::AbstractArray{T, 3}) where {T}
+    (bs = size(a, 3)) == size(b, 3) || error("batch size mismatch")
     res = similar(a, size(a, 1), size(b, 2), bs)
     for i in 1:bs
         res[:, :, i] = a[:, :, i] * b[:, :, i]
@@ -224,21 +192,18 @@ function batchedmul(a::AbstractArray{T, 3}, b::AbstractArray{T, 3}) where {T}
     return res
 end
 
-function Base.:*(a::SMBatch{T1, A}, b::SMBatch{T2, B}) where {T1<:AbstractMatrix, T2<:AbstractVector, A, B}
+function Base.:*(a::MaskedBatch{T1, A}, b::MaskedBatch{T2, B}) where {T1<:AbstractMatrix, T2<:AbstractVector, A, B}
     A[2] == B[1] || error("cannot contract axes with static and dynamic dimension")
     data = batchedmul(a.data, b.data)
-    res = batchtype(b){T2, (A[1],)}(data, a.sizes[1:1, :])
-    b isa MaskedBatch && (res.mask = batchedmul(a.mask[:, 1:1, :], b.mask[1:1, :]))
-    return res
+    mask = batchedmul(a.mask[:, 1:1, :], b.mask[1:1, :])
+    return MaskedBatch{T2, (A[1],)}(data, mask)
 end
 
-function Base.:*(a::SMBatch{T, A}, b::SMBatch{T, B}) where {T<:AbstractMatrix, A, B}
+function Base.:*(a::MaskedBatch{T, A}, b::MaskedBatch{T, B}) where {T<:AbstractMatrix, A, B}
     A[2] == B[1] || error("cannot contract axes with static and dynamic dimension")
     data = batchedmul(a.data, b.data)
-    sizes = vcat(a.sizes[1:1, :], b.sizes[2:2, :])
-    res = batchtype(a){T, (A[1], B[2])}(data, sizes)
-    b isa MaskedBatch && (res.mask = batchedmul(a.mask[:, 1:1, :], b.mask[1:1, :, :]))
-    return res
+    mask = batchedmul(a.mask[:, 1:1, :], b.mask[1:1, :, :])
+    return MaskedBatch{T, (A[1], B[2])}(data, mask)
 end
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,23 +11,22 @@ f(x) = tanh.(x)
 g(x) = tanh.(x .+ b)
 h(x) = tanh.(W*x .+ b)
 
-axisinfo = (false, true)
-data(n) = rand(5, n)
-xs = [data(3), data(4)]
-x1 = VectorBatch(xs, axisinfo)
-x2 = SizedBatch(xs, axisinfo)
-x3 = MaskedBatch(xs, axisinfo)
+xs = [rand(5, 3), rand(5, 4)]
+x1 = VectorBatch(xs, (false, true))
+x2 = MaskedBatch(xs, (false, true))
 
-for other in (x1, x2, x3)
-    @test x1 == VectorBatch(other)
-    @test x2 == SizedBatch(other)
-    @test x3 == MaskedBatch(other)
-end
+@test x1 == VectorBatch(x2)
+@test x2 == MaskedBatch(x1)
 
 for fn in (f, g, h)
-    @test SizedBatch(fn(x1)) ≈ fn(x2)
-    @test MaskedBatch(fn(x1)) ≈ fn(x3)
+    @test MaskedBatch(fn(x1)) ≈ fn(x2)
 end
+
+ys = [rand(4, 5), rand(2, 5)]
+y1 = VectorBatch(ys, (true, false))
+y2 = MaskedBatch(ys, (true, false))
+
+@test MaskedBatch(y1 * x1) ≈ y2 * x2
 
 # function attention(q, k, v) # q::N×D, k::M×D, v::M×D
 #     alpha = q*k' # ::N×M


### PR DESCRIPTION
This PR removes `SizedBatch`, allowing significant code simplification. It also fixes correctness for products of two `VectorBatch`es.

It looks like `MaskedBatch` is at least as fast and simple as `SizedBatch` for every operation other than (not yet implemented) conversion to and from `CatBatch` or another packed format (where we need a cumulative sum of `sizes`). Unlike `SizedBatch`, it also allows cheap `_rezero`, so it's better for `broadcast` calls with non-zero-preserving functions.